### PR TITLE
Footer・Mainコンポーネントの作成

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,12 +1,10 @@
 import '@/styles/globals.css';
-import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider as MUIThemeProvider } from '@mui/material';
 import { theme } from '@/utils/clients/muiThemeClient';
 
 const withThemeProvider = (Story, context) => {
   return (
     <MUIThemeProvider theme={theme}>
-      <CssBaseline />
       <Story {...context} />
     </MUIThemeProvider>
   );

--- a/src/features/layouts/Footer.stories.tsx
+++ b/src/features/layouts/Footer.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Footer } from './Footer'
+import { bgColor } from '@/utils/clients/themeClient'
+
+const meta: Meta = {
+  title: 'Features/Layout',
+  component: Footer,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          backgroundColor: bgColor.white,
+          height: '100vh'
+        }}
+      >
+        <Story />
+      </div>
+    )
+  ]
+}
+
+export default meta
+
+type Story = StoryObj<typeof Footer>
+
+export const footer: Story = {
+  args: {}
+}

--- a/src/features/layouts/Footer.tsx
+++ b/src/features/layouts/Footer.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled'
+import { bgColor } from '@/utils/clients/themeClient'
+import { BaseText } from '@/utils/themes'
+import IconFolder from '@/utils/assets/icon_folder.svg'
+
+const FooterContainer = styled('div')`
+  align-items: flex-start;
+  background-color: ${bgColor.black};
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 32px;
+  width: 100%;
+`
+
+const IconTextPair = styled('div')`
+  align-items: center;
+  display: flex;
+  gap: 8px;
+`
+
+const FooterLeftWrapper = styled('div')`
+  display: flex;
+  gap: 24px;
+`
+
+interface FooterLinkProps {
+  text: string
+}
+
+const FooterLink = ({ text }: FooterLinkProps) => (
+  <IconTextPair>
+    <BaseText className="-white -small -line-height-large">{text}</BaseText>
+    <IconFolder />
+  </IconTextPair>
+)
+
+export const Footer = () => {
+  return (
+    <FooterContainer>
+      <FooterLeftWrapper>
+        <FooterLink text="利用規約" />
+        <FooterLink text="プライバシーポリシー" />
+      </FooterLeftWrapper>
+      <BaseText className="-white -small -line-height-large -end">
+        © 2023 Landit Inc.
+      </BaseText>
+    </FooterContainer>
+  )
+}

--- a/src/features/layouts/Main.stories.tsx
+++ b/src/features/layouts/Main.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Main } from './Main'
+
+const meta: Meta = {
+  title: 'Features/Layout',
+  component: Main
+}
+
+export default meta
+
+type Story = StoryObj<typeof Main>
+
+export const main: Story = {
+  args: {}
+}

--- a/src/features/layouts/Main.tsx
+++ b/src/features/layouts/Main.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled'
+import { bgColor } from '@/utils/clients/themeClient'
+
+const ContentContainer = styled('div')`
+  background:
+    url('/images/background_image.png'),
+    ${bgColor.black} 50% / cover no-repeat;
+  background-blend-mode: normal;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+`
+
+export const Main = () => {
+  return <ContentContainer />
+}

--- a/src/features/layouts/index.ts
+++ b/src/features/layouts/index.ts
@@ -1,1 +1,2 @@
 export { Header } from './Header'
+export { Footer } from './Footer'

--- a/src/features/layouts/index.ts
+++ b/src/features/layouts/index.ts
@@ -1,2 +1,3 @@
 export { Header } from './Header'
 export { Footer } from './Footer'
+export { Main } from './Main'

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,14 @@
 import styled from '@emotion/styled'
 import Head from 'next/head'
-import { Header } from '@/features/layouts'
+import { Footer, Header } from '@/features/layouts'
 import { bgColor } from '@/utils/clients/themeClient'
+
+const Main = styled('main')`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100%;
+`
 
 const ContentContainer = styled('div')`
   background:
@@ -9,7 +16,7 @@ const ContentContainer = styled('div')`
     ${bgColor.black} 50% / cover no-repeat;
   background-blend-mode: normal;
   display: flex;
-  height: calc(100vh - 74px);
+  height: 100%;
   justify-content: center;
   position: relative;
   width: 100%;
@@ -28,10 +35,11 @@ const Home = () => {
         {/* TODO: 指定のファビコンに修正する必要あり */}
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main>
+      <Main>
         <Header />
         <ContentContainer />
-      </main>
+        <Footer />
+      </Main>
     </>
   )
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,24 +1,11 @@
 import styled from '@emotion/styled'
 import Head from 'next/head'
-import { Footer, Header } from '@/features/layouts'
-import { bgColor } from '@/utils/clients/themeClient'
+import { Footer, Header, Main } from '@/features/layouts'
 
-const Main = styled('main')`
+const MainContainer = styled('main')`
   display: flex;
   flex-direction: column;
   height: 100vh;
-  width: 100%;
-`
-
-const ContentContainer = styled('div')`
-  background:
-    url('/images/background_image.png'),
-    ${bgColor.black} 50% / cover no-repeat;
-  background-blend-mode: normal;
-  display: flex;
-  height: 100%;
-  justify-content: center;
-  position: relative;
   width: 100%;
 `
 
@@ -32,14 +19,14 @@ const Home = () => {
           content="不動産取引をグラフ表記するアプリケーション"
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        {/* TODO: 指定のファビコンに修正する必要あり */}
+        {/* TODO: 指定のファビコンの提示があれば修正する */}
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Main>
+      <MainContainer>
         <Header />
-        <ContentContainer />
+        <Main />
         <Footer />
-      </Main>
+      </MainContainer>
     </>
   )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,14 +12,7 @@
 body {
   background-color: #ffffff;
     font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    Oxygen-Sans,
-    Ubuntu,
-    Cantarell,
-    "Helvetica Neue",
+    Noto Sans JP,
     sans-serif;
   line-height: 1.5;
   min-height: 100vh;

--- a/src/utils/themes/BaseText.ts
+++ b/src/utils/themes/BaseText.ts
@@ -1,0 +1,66 @@
+import { styled } from '@mui/material/styles'
+import {
+  fontColor,
+  fontSize,
+  fontWeight,
+  lineHeight
+} from '@/utils/clients/themeClient'
+
+/**
+ * 統一したタイトルのレイアウトを実装するために設置
+ * 使用ファイルでインポートし必要であれば上書きでレイアウトを調整すること
+ */
+export const BaseText = styled('div')`
+  color: ${fontColor.black};
+  font-size: ${fontSize.medium};
+  font-weight: ${fontWeight.normal};
+  line-height: ${lineHeight.medium};
+  white-space: pre-line;
+  word-break: break-all;
+
+  &.-red {
+    color: ${fontColor.red};
+  }
+  &.-white {
+    color: ${fontColor.white};
+  }
+  &.-left {
+    text-align: left;
+  }
+  &.-end {
+    text-align: end;
+  }
+  &.-center {
+    text-align: center;
+  }
+  &.-inline {
+    display: inline-block;
+  }
+  &.-bold {
+    font-weight: ${fontWeight.bold};
+  }
+  &.-full {
+    width: 100%;
+  }
+  &.-small {
+    font-size: ${fontSize.small};
+  }
+  &.-medium {
+    font-size: ${fontSize.medium};
+  }
+  &.-large {
+    font-size: ${fontSize.large};
+  }
+  &.-xl {
+    font-size: ${fontSize.xl};
+  }
+  &.-xxl {
+    font-size: ${fontSize.xxl};
+  }
+  &.-xxxl {
+    font-size: ${fontSize.xxxl};
+  }
+  &.-line-height-large {
+    line-height: ${lineHeight.large};
+  }
+`

--- a/src/utils/themes/index.ts
+++ b/src/utils/themes/index.ts
@@ -1,0 +1,1 @@
+export { BaseText } from './BaseText'


### PR DESCRIPTION
### 内容
Footer・Mainコンポーネント・ページを一旦作成
今後さらに粒度を細かくコンポーネント化する必要があれば、適宜対応していく

### 動作確認
<img width="1428" alt="スクリーンショット 2023-12-02 22 14 31" src="https://github.com/villageon/real-estate-grapher/assets/89616496/b9be2e85-524a-4c47-b3e6-0dd98c093056">
